### PR TITLE
CI: add build workflow, fix type errors, update release workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,15 +1,20 @@
-name: Release
+name: CI
 
 on:
   push:
-    tags:
-      - '[0-9]+.*'
+    branches: [dev, main]
+  pull_request:
+    branches: [dev, main]
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to build'
+        required: false
+        default: 'dev'
 
 jobs:
-  release:
+  build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
 
     steps:
       - uses: actions/checkout@v4
@@ -32,18 +37,15 @@ jobs:
       - name: Type check
         run: bun check
 
-      - name: Build plugin
+      - name: Build
         run: bun run build
 
-      - name: Create GitHub Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          tag="${GITHUB_REF#refs/tags/}"
-          gh release create "$tag" \
-            --title="$tag" \
-            --generate-notes \
-            --draft \
-            build/prod/main.js \
-            build/prod/styles.css \
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: plugin-build-${{ github.sha }}
+          path: |
+            build/prod/main.js
+            build/prod/styles.css
             manifest.json
+          retention-days: 7

--- a/bun.lock
+++ b/bun.lock
@@ -40,6 +40,7 @@
         "@tsconfig/svelte": "^5.0.8",
         "@types/d3-force": "^3.0.10",
         "@types/diff": "^8.0.0",
+        "@types/node": "^25.5.0",
         "@vitest/coverage-v8": "^4.0.18",
         "autoprefixer": "^10.4.27",
         "btca": "2.0.5",
@@ -317,6 +318,8 @@
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
+
+    "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
     "@types/tern": ["@types/tern@0.23.9", "", { "dependencies": { "@types/estree": "*" } }, "sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw=="],
 
@@ -919,6 +922,8 @@
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "umap-js": ["umap-js@1.4.0", "", { "dependencies": { "ml-levenberg-marquardt": "^2.0.0" } }, "sha512-xxpviF9wUO6Nxrx+C58SoDgea+h2PnVaRPKDelWv0HotmY6BeWeh0kAPJoumfqUkzUvowGsYfMbnsWI0b9do+A=="],
+
+    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@tsconfig/svelte": "^5.0.8",
     "@types/d3-force": "^3.0.10",
     "@types/diff": "^8.0.0",
+    "@types/node": "^25.5.0",
     "@vitest/coverage-v8": "^4.0.18",
     "autoprefixer": "^10.4.27",
     "btca": "2.0.5",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
     "strict": true,
-    "types": ["svelte", "vite/client"],
+    "types": ["svelte", "vite/client", "node"],
     "plugins": [
       {
         "name": "typescript-svelte-plugin",


### PR DESCRIPTION
## What

- New `ci.yaml` workflow: runs type check (`bun check`) and build on push/PR to dev/main
- Added `@types/node` + `"node"` in tsconfig types to fix 17 type errors (`node:http`, `node:buffer`, `node:async_hooks`)
- Updated `release.yml`: actions v3->v4, setup-bun v1->v2, bun cache, `--frozen-lockfile`, type check step, auto-generated release notes

## Why

Type check was failing in CI due to missing Node type declarations. The release workflow was outdated (old action versions, no lockfile pinning, manual `papa-ts` injection hack).