### PR TITLE
fix: strip inlined attachment content from human message on chat reload

### DIFF
--- a/src/stores/chatStore.svelte.ts
+++ b/src/stores/chatStore.svelte.ts
@@ -696,10 +696,24 @@ export function deriveMessagePairsFromActiveCheckpoint(
  * ---------------------------------------------------------------------------*/
 
 /**
- * Extracts text content from a BaseMessage.
- * Uses the .text getter which handles string and ContentBlock[] formats.
+ * Extracts the user-facing query text from a BaseMessage.
+ *
+ * For a multimodal HumanMessage (content is a ContentBlock[]), `Agent.buildMessageContent`
+ * always places the user's query as the sole leading `{ type: "text" }` block and appends
+ * attachment-derived blocks (inlined `--- File: … ---` / `--- PDF: … ---` dumps, image
+ * notices) after it. The LangChain `.text` getter concatenates ALL text blocks, which would
+ * leak those inlined attachment dumps into the message bubble on reload — so when content is
+ * an array we return only the first text block. For a plain string content we use `.text`.
  */
 function extractTextContent(message: BaseMessage): string {
+	const content = message.content;
+	if (Array.isArray(content)) {
+		const firstText = content.find(
+			(block): block is { type: "text"; text: string } =>
+				typeof block === "object" && block !== null && (block as { type?: unknown }).type === "text",
+		);
+		return firstText?.text ?? "";
+	}
 	return message.text || "";
 }
 


### PR DESCRIPTION
## Problem

When a chat is reopened, attached file content (markdown/text/csv/json, and non-native-provider PDFs) that `Agent.buildMessageContent` inlines into the `HumanMessage` — as `--- File: <name> ---\n<content>\n--- End File ---` text blocks — leaks into the **user message bubble** in the UI. The file then shows up **twice**: as an attachment chip *and* dumped raw into the bubble text.

### Root cause

- **Live send** stores the clean, raw query string the user typed as display text.
- **Reload** re-derives display text from the persisted LangChain `HumanMessage` in `baseMessagesToMessagePairs`, via `extractTextContent(msg)` → `msg.text`. LangChain's `.text` getter **concatenates every `type: "text"` block**, including the inlined attachment dumps. No step strips them (unlike `stripAugmentedSuffix`, which only removes the visible-notes/selection suffix).

## Fix

`extractTextContent` now returns **only the leading text block** when `message.content` is an array. This matches `buildMessageContent`'s invariant: the user query is always the sole first `{ type: "text" }` block, and attachment-derived blocks follow it. `stripAugmentedSuffix` still runs correctly, since the visible-notes suffix is appended to the query string itself (so it lives inside that first block).

Attachment chips continue to render from `additional_kwargs.attachments` as before.

## Verification

- `bun run check` — no new errors (the 5 reported are pre-existing in `pendingChangesStore`/`GraphCanvas`, present on `dev` before this change).
- `bun run format` — clean, no changes.

Manual reload verification in the live vault still recommended before merge.